### PR TITLE
Functionality for performing activities

### DIFF
--- a/cram_plan_library/src/perform.lisp
+++ b/cram_plan_library/src/perform.lisp
@@ -29,7 +29,50 @@
 (in-package :plan-lib)
 
 (def-goal (perform ?action-designator)
-  (pm-execute-matching ?action-designator))
+  "If there is a clash between a plan that implements a designator and
+an available process module that implements the same designator,
+the preference will always be given to the process module.
+If the action designator has a GOAL key it will be checked if the goal holds.
+TODO: it might be nice to have a clash check and let the user know.
+For that one would need an assertion like matching-plan.
+Then the check would be, if both matching-pm and matching-plan, issue a warning.
+The trade-off is: do we want to define matching-plan for each plan to get this warning?
+TODO: there might be multiple plans that can execute the same action designator.
+In PMs the solution is: try-each-in-order.
+In plans it would make more sense to explicitly specify the order.
+For now we will only take the first action designator solution.
+For future we can implement something like next-different-action-solution
+similar to what we have for locations."
+  (flet ((convert-desig-goal-to-occasion (keyword-expression)
+           (destructuring-bind (occasion &rest params)
+               keyword-expression
+             (cons (intern (string-upcase occasion) :cram-plan-occasions-events) params)))
+         (try-reference-action-designator (action-designator)
+           (handler-case (reference ?action-designator)
+             (designator-error (e)
+               (declare (ignore e))
+               (cpl:fail "Action designator ~a could not be resolved.~%Cannot perform action."
+                         action-designator)))))
+
+    (if (matching-available-process-modules ?action-designator)
+        (pm-execute-matching ?action-designator)
+        (destructuring-bind (command &rest arguments)
+            (try-reference-action-designator ?action-designator)
+          (if (fboundp command)
+              (let ((desig-goal (desig-prop-value ?action-designator :goal)))
+                (if desig-goal
+                    (let ((occasion (convert-desig-goal-to-occasion desig-goal)))
+                      (if (holds occasion)
+                          (ros-info (achieve plan-lib)
+                                    "Action goal `~a' already achieved."
+                                    occasion)
+                          (apply command arguments))
+                      (unless (holds occasion)
+                        (cpl:fail "Goal `~a' of action `~a' was not achieved."
+                                  ?action-designator occasion)))
+                    (apply command arguments)))
+              (cpl:fail "Action designator `~a' resolved to cram function `~a',
+but it isn't defined. Cannot perform action." ?action-designator command))))))
 
 (def-goal (perform-on-process-module ?module ?action-designator)
   (pm-execute ?module ?action-designator))

--- a/cram_plan_library/src/perform.lisp
+++ b/cram_plan_library/src/perform.lisp
@@ -36,11 +36,7 @@
 
 (def-goal (monitor-action ?action-designator)
   (let ((matching-process-modules
-          (remove-if
-           (lambda (matching-process-module)
-             (eql nil (cram-process-modules:get-running-process-module
-                       matching-process-module)))
-           (matching-process-module-names ?action-designator))))
+          (matching-available-process-modules ?action-designator :fail-if-none t))) 
     (monitor-process-module (car matching-process-modules) :designators (list ?action-designator))
     ;; (par-loop (module matching-process-modules)
     ;;   (monitor-process-module module :designators (list ?action-designator)))


### PR DESCRIPTION
For usage please consult the corresponding tutorial: http://cram-system.org/tutorials/intermediate/performing_plans

Please pay attention at the restrictions chapter of the tutorial.

This new functionality should not affect anything that is currently implemented, at least not in `cram-plan-library`. However, if there were designators that didn't have a matching process module and relied on the corresponding error, the behaviour will differ. Please test you scenario code before merging this in.

Depends on https://github.com/cram2/cram_core/pull/7

When this is merged in, I suggest to leave the plan library as it is and only implement `perform` for activities in the highest-level plans that should have their corresponding equivalent in PRAC-generated plans. From Michael's perspective, these highest-level plans should be callable with `(perform action-designator)`. The rest isn't that crucial at the moment.