### PR TITLE
in robot-interfaces added robot-tool-frame predicate:

### DIFF
--- a/cram_robot_interfaces/src/arms.lisp
+++ b/cram_robot_interfaces/src/arms.lisp
@@ -29,6 +29,7 @@
 (in-package :cram-robot-interfaces)
 
 (def-fact-group arms (arm required-arms available-arms end-effector-link
+                          robot-tool-frame
                           gripper-joint gripper-link
                           robot-arms-parking-joint-states end-effector-parking-pose
                           robot-pre-grasp-joint-states planning-group)
@@ -48,6 +49,10 @@
 
   ;; Defines end-effector links for arms.
   (<- (end-effector-link ?robot ?arm ?link-name)
+    (fail))
+
+  ;; Defines tool frames for arms.
+  (<- (robot-tool-frame ?robot ?arm ?frame)
     (fail))
 
   ;; Defines links of the grippers of the robot

--- a/cram_robot_interfaces/src/package.lisp
+++ b/cram_robot_interfaces/src/package.lisp
@@ -40,7 +40,8 @@
    #:robot-pan-tilt-links #:robot-pan-tilt-joints
    ;; arms
    #:arm #:required-arms #:available-arms
-   #:end-effector-link #:gripper-link #:gripper-joint #:planning-group
+   #:end-effector-link #:gripper-link #:gripper-joint #:robot-tool-frame
+   #:planning-group
    #:robot-arms-parking-joint-states #:end-effector-parking-pose
    #:robot-pre-grasp-joint-states
    ;; grasps


### PR DESCRIPTION
for storing the tool frames of the arms.

The implementation for PR2 is in `cram_pr2`, the pull request will follow.