### PR TITLE
Added predicates to get arm links and joints.

### DIFF
--- a/cram_robot_interfaces/src/arms.lisp
+++ b/cram_robot_interfaces/src/arms.lisp
@@ -28,13 +28,21 @@
 
 (in-package :cram-robot-interfaces)
 
-(def-fact-group arms (arm required-arms available-arms end-effector-link
+(def-fact-group arms (arm arm-joints arm-links required-arms available-arms end-effector-link
                           robot-tool-frame
                           gripper-joint gripper-link
                           robot-arms-parking-joint-states end-effector-parking-pose
                           robot-pre-grasp-joint-states planning-group)
   ;; Unifies ?side with the name of an arm that is present on the ?robot.
   (<- (arm ?robot ?arm)
+    (fail))
+
+  ;; Unifies ?arm with the list of joints for that arm.
+  (<- (arm-joints ?robot ?arm ?joints)
+    (fail))
+
+  ;; Unifies ?arm with a list of links for that arm (includes gripper links).
+  (<- (arm-links ?robot ?arm ?links)
     (fail))
 
   ;; ?sides is unified with the list of arms that are required to

--- a/cram_robot_interfaces/src/arms.lisp
+++ b/cram_robot_interfaces/src/arms.lisp
@@ -59,6 +59,10 @@
   (<- (end-effector-link ?robot ?arm ?link-name)
     (fail))
 
+  ;; Unifies ?arm with a list of links for the hand of that arm.
+  (<- (hand-links ?robot ?arm ?links)
+    (fail))
+
   ;; Defines tool frames for arms.
   (<- (robot-tool-frame ?robot ?arm ?frame)
     (fail))

--- a/cram_robot_interfaces/src/arms.lisp
+++ b/cram_robot_interfaces/src/arms.lisp
@@ -28,7 +28,7 @@
 
 (in-package :cram-robot-interfaces)
 
-(def-fact-group arms (arm arm-joints arm-links required-arms available-arms end-effector-link
+(def-fact-group arms (arm arm-joints arm-links hand-links required-arms available-arms end-effector-link
                           robot-tool-frame
                           gripper-joint gripper-link
                           robot-arms-parking-joint-states end-effector-parking-pose

--- a/cram_robot_interfaces/src/package.lisp
+++ b/cram_robot_interfaces/src/package.lisp
@@ -39,7 +39,7 @@
    #:camera-frame #:camera-minimal-height #:camera-maximal-height
    #:robot-pan-tilt-links #:robot-pan-tilt-joints
    ;; arms
-   #:arm #:required-arms #:available-arms
+   #:arm #:arm-joints #:arm-links #:required-arms #:available-arms
    #:end-effector-link #:gripper-link #:gripper-joint #:robot-tool-frame
    #:planning-group
    #:robot-arms-parking-joint-states #:end-effector-parking-pose


### PR DESCRIPTION
Purpose: in the pr2-manipulation-process-module, there are places where lists of joints and links are needed. These are now hard-coded into the process-module, but it would be nicer if they could be queried from the robot knowledge data base. One reason is that it would make the pr2-manipulation-process-module code robot agnostic and reusable for other robots as well.
